### PR TITLE
Use Node assert

### DIFF
--- a/src/rules/prefer-task-library/rule.ts
+++ b/src/rules/prefer-task-library/rule.ts
@@ -1,6 +1,8 @@
 import { AST_NODE_TYPES, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
 
-import { assert, createEslintRule } from "../../util";
+import assert from "assert";
+
+import { createEslintRule } from "../../util";
 
 export const RULE_NAME = "prefer-task-library";
 

--- a/src/rules/prefer-task-library/rule.ts
+++ b/src/rules/prefer-task-library/rule.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
 
-import assert from "assert";
+import assert from "node:assert";
 
 import { createEslintRule } from "../../util";
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,10 +9,3 @@ export interface PluginDocumentation {
 export const createEslintRule = RuleCreator<PluginDocumentation>((name) => {
 	return `https://github.com/christopher-buss/eslint-plugin-roblox-ts-x/tree/main/src/rules/${name}/documentation.md`;
 });
-
-export function assert(condition: any, message?: string): asserts condition {
-	// eslint-disable-next-line ts/strict-boolean-expressions -- Required for assert
-	if (!condition) {
-		throw new Error(message);
-	}
-}


### PR DESCRIPTION
I think Node's assert used to be missing the `: asserts condition` typing, so it wasn't super useful. 

This is no longer the case.